### PR TITLE
Fix File Upload sync for Gravity Forms 2.10+ JSON storage format

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 == Changelog ==
+= 0.0.4 =
+* FIX: compatibility with Gravity Forms 2.10+ JSON storage format for File Upload fields (single-file fields are now also stored as JSON arrays).
+* FIX: modify_db() re-encoded the original value instead of the rewritten one during Compatibility Files Sync, and the JSON validity check now requires an array.
+
 = 0.0.3 =
 * Tested with Gravity Forms version 2.9.16.1
 

--- a/class-gravity-forms.php
+++ b/class-gravity-forms.php
@@ -83,8 +83,15 @@ class GravityForms extends Compatibility {
     if ($type == 'fileupload') {
       $dir = wp_upload_dir();
 
-      if ($field->multipleFiles) {
-        $value = json_decode($value, true);
+      // GF 2.10+ standardized the File Upload storage format so single-file
+      // fields are also stored as a JSON array. Detect the shape from the
+      // value itself rather than from $field->multipleFiles so we work on
+      // both old and new GF versions.
+      $decoded = is_string($value) ? json_decode($value, true) : null;
+      $was_json = is_array($decoded);
+
+      if ($was_json) {
+        $value = $decoded;
       } else {
         $value = array($value);
       }
@@ -109,7 +116,9 @@ class GravityForms extends Compatibility {
         }
       }
 
-      if ($field->multipleFiles) {
+      // Re-encode in the same shape we received so older GF versions keep
+      // storing single-file values as a plain string.
+      if ($was_json) {
         $value = wp_json_encode($value);
       } else {
         $value = array_pop($value);
@@ -205,7 +214,7 @@ class GravityForms extends Compatibility {
         // Check if value is json encoded, if so, cycle through array and replace URLs.
         $result = json_decode($value);
 
-        if ( json_last_error() === 0 ) {
+        if ( json_last_error() === JSON_ERROR_NONE && is_array($result) ) {
           foreach ($result as $k => $v) {
             $position = strpos($v, $dir['baseurl']);
 
@@ -214,7 +223,7 @@ class GravityForms extends Compatibility {
             }
           }
 
-          $result = wp_json_encode($value);
+          $result = wp_json_encode($result);
         } else {
           $position = strpos($value, $dir['baseurl']);
 

--- a/class-gravity-forms.php
+++ b/class-gravity-forms.php
@@ -86,14 +86,14 @@ class GravityForms extends Compatibility {
       // GF 2.10+ standardized the File Upload storage format so single-file
       // fields are also stored as a JSON array. Detect the shape from the
       // value itself rather than from $field->multipleFiles so we work on
-      // both old and new GF versions.
-      $decoded = is_string($value) ? json_decode($value, true) : null;
-      $was_json = is_array($decoded);
-
-      if ($was_json) {
-        $value = $decoded;
+      // both old and new GF versions. Also tolerate an already-decoded array
+      // in case another filter ran ahead of us.
+      if (is_array($value)) {
+        $was_json = true;
       } else {
-        $value = array($value);
+        $decoded = is_string($value) ? json_decode($value, true) : null;
+        $was_json = is_array($decoded);
+        $value = $was_json ? $decoded : array($value);
       }
 
       foreach ($value as $k => $v) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 0.0.3
+Stable tag: 0.0.4
 
 Provides compatibility between the Gravity Forms and the WP-Stateless plugins.
 
@@ -21,7 +21,7 @@ Provides compatibility between the [Gravity Forms](https://www.gravityforms.com/
 
 = Notes =
 
-* Tested with Gravity Forms plugin version 2.9.16.1
+* Tested with Gravity Forms plugin version 2.10.x
 
 = Support, Feedback, & Contribute =
 
@@ -44,6 +44,10 @@ To ensure new releases cause as little disruption as possible, we rely on early 
 == Upgrade Notice ==
 
 == Changelog ==
+= 0.0.4 =
+* FIX: compatibility with Gravity Forms 2.10+ JSON storage format for File Upload fields (single-file fields are now also stored as JSON arrays).
+* FIX: modify_db() re-encoded the original value instead of the rewritten one during Compatibility Files Sync, and the JSON validity check now requires an array.
+
 = 0.0.3 =
 * Tested with Gravity Forms version 2.9.16.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Provides compatibility between the [Gravity Forms](https://www.gravityforms.com/
 
 = Notes =
 
-* Tested with Gravity Forms plugin version 2.10.x
+* Tested with Gravity Forms plugin version 2.10.2
 
 = Support, Feedback, & Contribute =
 


### PR DESCRIPTION
Fixes #15

## Summary

- Detect the File Upload field's stored shape from its value (JSON array vs raw string) instead of from `$field->multipleFiles`. GF 2.10+ stores single-file fields as a JSON array too, so the old branch never decoded them and `strpos('gravity_forms/')` failed on the JSON-escaped slashes — the GCS sync action was never fired and the URL was never rewritten.
- Re-encode in the original shape, so older GF releases that still store single-file values as a plain string keep the same DB layout.
- `modify_db()`: fix a re-encode bug where the JSON branch wrote `wp_json_encode($value)` (the original raw string) instead of `wp_json_encode($result)` (the rewritten array), which silently dropped the Sync-tab URL rewrites. Also tighten the JSON validity check to require an array so a `json_decode`'d scalar does not trip a PHP 8 warning on `foreach`.
- Bump version to 0.0.4 and add changelog entries.

The `post_image` branch is unchanged — that field type uses GF's legacy `|:|`-delimited string and was not affected by the 2.10 storage change.

## Validation

Verified against a live production site running Gravity Forms 2.10.2 with WP-Stateless. After deploying the fix, new File Upload submissions are uploaded to GCS and the entry meta is rewritten to the `storage.googleapis.com/<bucket>/gravity_forms/...` URL. The "view file" link on the Entries screen serves the file correctly. Pre-existing entries created before the fix still hold the local URL (expected — the save filter only fires on submission).

## Test plan

- [x] GF 2.10+: submit a form with a single File Upload field; entry meta contains a `storage.googleapis.com/...` URL and the file exists in the bucket.
- [x] GF 2.10+: same with a multi-file File Upload field.
- [x] GF < 2.10: submit a single-file upload; the meta value is still a plain string (not wrapped in JSON) and the URL is rewritten.
- [x] Run WP-Stateless Compatibility Files Sync against an entry that has a pre-existing local URL and confirm the URL is rewritten in `wp_gf_entry_meta`.